### PR TITLE
build windows with conan support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,11 +31,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-
     - uses: pypa/cibuildwheel@v2.3.1
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.14

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,13 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Cache Conan dependencies
+      if: matrix.os == 'windows-latest'
+      uses: actions/cache@v2
+      with:
+        path: $USERPROFILE/.conan
+        key: conan-${{ hashFiles('conanfile.txt') }}
+
     - uses: pypa/cibuildwheel@v2.3.1
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.14

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,15 +31,15 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install conan dependencies
-      if: matrix.os == 'windows-latest'
-      run: |
-        pip install conan
-        conan install . --build=openssl --install-folder $PWD/conan_build --remote conancenter
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
     - uses: pypa/cibuildwheel@v2.3.1
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.15
+        MACOSX_DEPLOYMENT_TARGET: 10.14
+        CIBW_TEST_COMMAND_WINDOWS: ''
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,29 +47,32 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Cache Conan dependencies
+    - name: Cache Conan
       id: cache-conan
       uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:
-        path:
-          $USERPROFILE/.conan
-          conan-build
-        key: conan-${{ hashFiles('conanfile.txt') }}-v1.1
+        path: |
+          conan_build
+          conan_data
+        key: conan-${{ matrix.os }}-${{ hashFiles('conanfile.txt') }}
 
     - name: Set up Windows Python ${{ matrix.python_version }}
       uses: actions/setup-python@v2
       if: matrix.os == 'windows-latest' && steps.cache-conan.outputs.cache-hit != 'true'
       with:
-        python-version: ${{ matrix.python_version }}
+        python-version: '3.x'
 
     - name: Install conan for Windows
       if: matrix.os == 'windows-latest' && steps.cache-conan.outputs.cache-hit != 'true'
       run: |
         pip install pip --upgrade
         pip install conan
-        call .\conan_install.bat
-      shell: cmd
+        conan profile new default --detect
+        conan profile update "settings.compiler=Visual Studio" default
+        conan profile update "settings.compiler.version=16" default
+        conan config set "storage.path=$env:GITHUB_WORKSPACE/conan_data"
+        conan install --build=openssl --install-folder conan_build .
 
     - uses: pypa/cibuildwheel@v2.3.1
       env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,8 +2,10 @@ name: Wheels
 
 on:
   push:
+    branches:
+      - 'master'
     tags:
-     - '*'
+      - '*'
     paths-ignore:
       - '*.md'
   pull_request:
@@ -12,7 +14,7 @@ on:
     paths-ignore:
       - '*.md'
 
-
+jobs:
   build_wheels:
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,23 +4,13 @@ on:
   push:
     tags:
      - '*'
-
-jobs:
-  build_sdist:
-    name: Build SDist
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Build SDist
-      run: pipx run build --sdist
-
-    - name: Check metadata
-      run: pipx run twine check dist/*
-
-    - uses: actions/upload-artifact@v2
-      with:
-        path: dist/*.tar.gz
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    branches:
+      - 'master'
+    paths-ignore:
+      - '*.md'
 
 
   build_wheels:
@@ -30,14 +20,20 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          # - windows-latest
+          # - ubuntu-latest
+          # - macos-latest
+          - windows-latest
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+
+    - name: Install conan dependencies
+      if: matrix.os == 'windows-latest'
+      run: |
+        pip install conan
+        conan install . --build=openssl --install-folder $PWD/conan_build --remote conancenter
 
     - uses: pypa/cibuildwheel@v2.3.1
       env:
@@ -51,22 +47,3 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: wheelhouse/*.whl
-
-
-  upload_all:
-    name: Upload if release
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/setup-python@v2
-
-    - uses: actions/download-artifact@v2
-      with:
-        name: artifact
-        path: dist
-
-    - uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        user: jonathf
-        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,22 @@ on:
       - '*.md'
 
 jobs:
+  build_sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
   build_wheels:
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -22,8 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - ubuntu-latest
-          # - macos-latest
+          - ubuntu-latest
+          - macos-latest
           - windows-latest
 
     steps:
@@ -32,22 +48,39 @@ jobs:
         submodules: recursive
 
     - name: Cache Conan dependencies
-      if: matrix.os == 'windows-latest'
+      id: cache-conan
       uses: actions/cache@v2
+      if: matrix.os == 'windows-latest'
       with:
         path: $USERPROFILE/.conan
         key: conan-${{ hashFiles('conanfile.txt') }}
 
+    - name: Set up Windows Python ${{ matrix.python_version }}
+      uses: actions/setup-python@v2
+      if: matrix.os == 'windows-latest'
+      with:
+        python-version: ${{ matrix.python_version }}
+
+    - name: Install conan for Windows
+      if: matrix.os == 'windows-latest' && steps.cache-conan.outputs.cache-hit != 'true'
+      run: |
+        pip install pip --upgrade
+        pip install conan
+        conan profile new default --detect
+        conan profile update "settings.compiler=Visual Studio" default
+        conan profile update "settings.compiler.version=16" default
+        conan install --build=openssl --install-folder conan_build .
+
     - uses: pypa/cibuildwheel@v2.3.1
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.14
-        CIBW_TEST_COMMAND_WINDOWS: ''
 
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v2
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
-        path: wheelhouse/*.whl
+        user: jonathf
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,8 +52,10 @@ jobs:
       uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:
-        path: $USERPROFILE/.conan
-        key: conan-${{ hashFiles('conanfile.txt') }}
+        path:
+          $USERPROFILE/.conan
+          conan-build
+        key: conan-${{ hashFiles('conanfile.txt') }}-v1.1
 
     - name: Set up Windows Python ${{ matrix.python_version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -79,8 +79,26 @@ jobs:
       run: git diff --exit-code
       shell: bash
 
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+
+  upload_all:
+    name: Upload if release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/setup-python@v2
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
     - uses: pypa/gh-action-pypi-publish@v1.4.2
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: jonathf
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,14 +3,14 @@ name: Wheels
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - '*'
     paths-ignore:
       - '*.md'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
     paths-ignore:
       - '*.md'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Set up Windows Python ${{ matrix.python_version }}
       uses: actions/setup-python@v2
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && steps.cache-conan.outputs.cache-hit != 'true'
       with:
         python-version: ${{ matrix.python_version }}
 
@@ -68,10 +68,8 @@ jobs:
       run: |
         pip install pip --upgrade
         pip install conan
-        conan profile new default --detect
-        conan profile update "settings.compiler=Visual Studio" default
-        conan profile update "settings.compiler.version=16" default
-        conan install --build=openssl --install-folder conan_build .
+        call .\conan_install.bat
+      shell: cmd
 
     - uses: pypa/cibuildwheel@v2.3.1
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+*build/
 develop-eggs/
 dist/
 downloads/
@@ -116,6 +116,9 @@ venv.bak/
 
 # Rope project settings
 .ropeproject
+
+# pycharm project settings
+.idea
 
 # mkdocs documentation
 /site

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Optionally the dependencies can be installed with [`conan`](https://github.com/c
 conan install --build=openssl --install-folder conan_build .
 
 # note, on Windows you might have to execute the following before
+conan profile new default --detect
 conan profile update "settings.compiler=Visual Studio" default
 conan profile update "settings.compiler.version=16" default
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ VROOM can also solve any mix of the above problem types.
 
 ## Installation
 
-Pyvroom currently makes binaries for on MacOS and Linux.
+Pyvroom currently makes binaries for on MacOS and Linux (Windows is WIP).
 
 Installation should be as simple as:
 
@@ -27,6 +27,21 @@ Installation should be as simple as:
 pip install pyvroom
 ```
 
+## Building
+
+Building the source distributions on another OS requires:
+- the `./build-requirements.txt` Python dependencies
+- `asio` headers installed
+- `openssl` & `crypto` libraries & headers installed
+
+Optionally the dependencies can be installed with [`conan`](https://github.com/conan-io/conan):
+```shell script
+conan install --build=openssl --install-folder conan_build .
+
+# note, on Windows you might have to execute the following before
+conan profile update "settings.compiler=Visual Studio" default
+conan profile update "settings.compiler.version=16" default
+```
 ## Basic usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -34,14 +34,9 @@ Building the source distributions on another OS requires:
 - `asio` headers installed
 - `openssl` & `crypto` libraries & headers installed
 
-Optionally the dependencies can be installed with [`conan`](https://github.com/conan-io/conan):
+Optionally the C++ dependencies can be installed with [`conan`](https://github.com/conan-io/conan):
 ```shell script
 conan install --build=openssl --install-folder conan_build .
-
-# note, on Windows you might have to execute the following before
-conan profile new default --detect
-conan profile update "settings.compiler=Visual Studio" default
-conan profile update "settings.compiler.version=16" default
 ```
 ## Basic usage
 

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,5 @@
+setuptools>=45
+wheel
+setuptools_scm>=6.2
+setuptools_scm_git_archive
+pybind11>=2.8.0

--- a/conan_install.bat
+++ b/conan_install.bat
@@ -1,0 +1,4 @@
+conan profile new default --detect
+conan profile update "settings.compiler=Visual Studio" default
+conan profile update "settings.compiler.version=16" default
+conan install --build=openssl --install-folder conan_build .

--- a/conan_install.bat
+++ b/conan_install.bat
@@ -1,4 +1,0 @@
-conan profile new default --detect
-conan profile update "settings.compiler=Visual Studio" default
-conan profile update "settings.compiler.version=16" default
-conan install --build=openssl --install-folder conan_build .

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+openssl/1.1.1m
+asio/1.21.0
+
+[generators]
+json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,3 @@ apk add openssl-dev
 before-all = """
 brew install asio
 """
-
-[tool.cibuildwheel.windows]
-before-all = [
-    'pip install pip --upgrade',
-    'pip install conan',
-    'conan profile new default --detect',
-    'conan profile update "settings.compiler=Visual Studio" default',
-    'conan profile update "settings.compiler.version=16" default',
-    'conan install --build=openssl --install-folder conan_build .'
-]
-test-command = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,11 @@ brew install asio
 """
 
 [tool.cibuildwheel.windows]
-before-all = """
-pip install pip --upgrade
-pip install conan
-conan profile update "settings.compiler=Visual Studio" default
-conan profile update "settings.compiler.version=16" default
-conan install --build=openssl --install-folder conan_build .
-"""
+before-all = [
+    'pip install pip --upgrade',
+    'pip install conan',
+    'conan profile update "settings.compiler=Visual Studio" default',
+    'conan profile update "settings.compiler.version=16" default',
+    'conan install --build=openssl --install-folder conan_build .'
+]
 test-command = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ brew install asio
 before-all = [
     'pip install pip --upgrade',
     'pip install conan',
+    'conan profile new default --detect',
     'conan profile update "settings.compiler=Visual Studio" default',
     'conan profile update "settings.compiler.version=16" default',
     'conan install --build=openssl --install-folder conan_build .'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,10 @@ brew install asio
 
 [tool.cibuildwheel.windows]
 before-all = """
-choco install -y openssl
+pip install pip --upgrade
+pip install conan
+conan profile update "settings.compiler=Visual Studio" default
+conan profile update "settings.compiler.version=16" default
+conan install --build=openssl --install-folder conan_build .
 """
+test-command = ''

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ ext_modules = [
         "_vroom",
         [os.path.join("src", "_vroom.cpp")],
         library_dirs=library_dirs,
-        extra_libraries=libraries,
+        libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     ),

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,17 @@ if conanfile:
         conan_deps = json.load(f)['dependencies']
     for dep in conan_deps:
         include = dep['include_paths']
-        libraries = dep['lib_paths']
+        libs = dep['libs']
+        system_libs = dep['system_libs']
+        libdirs = dep['lib_paths']
 
         include_dirs.extend(include)
-        if libraries:
-            library_dirs.extend(libraries)
+        if libs:
+            libraries.extend(libs)
+        if system_libs:
+            libraries.extend(system_libs)
+        if libdirs:
+            library_dirs.extend(libdirs)
 else:
     print('WARN: Conan not installed and/or no conan build detected. Assuming dependencies are installed.')
 
@@ -45,7 +51,12 @@ if platform.system() == "Darwin":
     include_dirs.append("/usr/local/opt/openssl@1.1/include")
     extra_link_args.insert(0, "-L/usr/local/opt/openssl@1.1/lib")
 elif platform.system() == "Windows":
-    extra_compile_args = ["-DNOGDI", "-DNOMINMAX", "-DASIO_STANDALONE"]
+    extra_compile_args = [
+        "-DNOGDI",
+        "-DNOMINMAX",
+        "-DWIN32_LEAN_AND_MEAN",
+        "-DASIO_STANDALONE"
+    ]
     extra_link_args = []
 
 ext_modules = [
@@ -53,6 +64,7 @@ ext_modules = [
         "_vroom",
         [os.path.join("src", "_vroom.cpp")],
         library_dirs=library_dirs,
+        libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     ),

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,58 @@
+import json
 import os
 import platform
+from pathlib import Path
 from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-extra_compile_args = [
-    "-MMD",
-    "-MP",
-    "-Wextra",
-    "-Wpedantic",
-    "-Wall",
-    "-O3",
-    "-DASIO_STANDALONE",
-    "-DNDEBUG",
-]
 extra_link_args = [
     "-lpthread",
     "-lssl",
     "-lcrypto",
 ]
+extra_compile_args = [
+        "-MMD",
+        "-MP",
+        "-Wextra",
+        "-Wpedantic",
+        "-Wall",
+        "-O3",
+        "-DASIO_STANDALONE",
+        "-DNDEBUG",
+    ]
 include_dirs = [os.path.join("vroom", "src")]
+libraries = []
+library_dirs = []
+
+# try conan dependency resolution
+conanfile = tuple(Path().rglob('conanbuildinfo.json'))
+if conanfile:
+    print("INFO: Using conan to resolve dependencies.")
+    with open(conanfile[0]) as f:
+        conan_deps = json.load(f)['dependencies']
+    for dep in conan_deps:
+        include = dep['include_paths']
+        libraries = dep['lib_paths']
+
+        include_dirs.extend(include)
+        if libraries:
+            library_dirs.extend(libraries)
+else:
+    print('WARN: Conan not installed and/or no conan build detected. Assuming dependencies are installed.')
 
 if platform.system() == "Darwin":
     # Homebrew puts include folders in weird places.
     include_dirs.append("/usr/local/opt/openssl@1.1/include")
     extra_link_args.insert(0, "-L/usr/local/opt/openssl@1.1/lib")
+elif platform.system() == "Windows":
+    extra_compile_args = ["-DNOGDI", "-DNOMINMAX", "-DASIO_STANDALONE"]
+    extra_link_args = []
 
 ext_modules = [
     Pybind11Extension(
         "_vroom",
         [os.path.join("src", "_vroom.cpp")],
+        library_dirs=library_dirs,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     ),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import platform
 from pathlib import Path
@@ -25,26 +26,18 @@ libraries = []
 library_dirs = []
 
 # try conan dependency resolution
-conanfile = tuple(Path().rglob('conanbuildinfo.json'))
+conanfile = tuple(Path(__file__).parent.resolve().rglob('conanbuildinfo.json'))
 if conanfile:
-    print("INFO: Using conan to resolve dependencies.")
-    with open(conanfile[0]) as f:
+    logging.info("Using conan to resolve dependencies.")
+    with conanfile[0].open() as f:
         conan_deps = json.load(f)['dependencies']
     for dep in conan_deps:
-        include = dep['include_paths']
-        libs = dep['libs']
-        system_libs = dep['system_libs']
-        libdirs = dep['lib_paths']
-
-        include_dirs.extend(include)
-        if libs:
-            libraries.extend(libs)
-        if system_libs:
-            libraries.extend(system_libs)
-        if libdirs:
-            library_dirs.extend(libdirs)
+        include_dirs.extend(dep['include_paths'])
+        libraries.extend(dep['libs'])
+        libraries.extend(dep['system_libs'])
+        library_dirs.extend(dep['lib_paths'])
 else:
-    print('WARN: Conan not installed and/or no conan build detected. Assuming dependencies are installed.')
+    logging.warning('Conan not installed and/or no conan build detected. Assuming dependencies are installed.')
 
 if platform.system() == "Darwin":
     # Homebrew puts include folders in weird places.

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ ext_modules = [
         "_vroom",
         [os.path.join("src", "_vroom.cpp")],
         library_dirs=library_dirs,
-        libraries=libraries,
+        extra_libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     ),


### PR DESCRIPTION
fixes #4 

~~still WIP, didn't try on windows yet. worked on linux though.~~ windows worked as well as on linux. so anyone should be able to use conan if desired.

one thing I realized: at least on linux conan installs only static libraries for openssl & crypto, so the final python .so is bigger but not much to do for auditwheel then.