### PR TITLE
install _vroom extension into vroom package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ ext_modules = [
 setup(
     cmdclass={"build_ext": build_ext},
     ext_modules=ext_modules,
+    ext_package='vroom',
     include_dirs=include_dirs,
     use_scm_version=True,
 )

--- a/src/vroom/__init__.py
+++ b/src/vroom/__init__.py
@@ -1,5 +1,5 @@
 """Vehicle routing open-source optimization machine (VROOM)."""
-from _vroom import JOB_TYPE, STEP_TYPE
+from ._vroom import JOB_TYPE, STEP_TYPE
 
 from .amount import Amount
 from .break_ import Break

--- a/src/vroom/amount.py
+++ b/src/vroom/amount.py
@@ -2,10 +2,10 @@
 from typing import Sequence, Union
 import numpy
 
-import _vroom
+from ._vroom import Amount as _Amount
 
 
-class Amount(_vroom.Amount):
+class Amount(_Amount):
     """An array of integers describing multidimensional quantities.
 
     Use amounts  to describe a problem with capacity restrictions. Those arrays
@@ -46,11 +46,11 @@ class Amount(_vroom.Amount):
         amount: Union[None, Sequence[int]] = None,
     ) -> None:
         args = []
-        if isinstance(amount, _vroom.Amount):
+        if isinstance(amount, _Amount):
             args.append(amount)
         elif amount is not None:
             args.append(numpy.asarray(amount, dtype="longlong"))
-        _vroom.Amount.__init__(self, *args)
+        _Amount.__init__(self, *args)
 
     def __getitem__(self, key: int) -> int:
         return numpy.asarray(self)[key]

--- a/src/vroom/break_.py
+++ b/src/vroom/break_.py
@@ -1,4 +1,4 @@
-from _vroom import _Break
+from ._vroom import _Break
 
 
 class Break(_Break):

--- a/src/vroom/input/forced_service.py
+++ b/src/vroom/input/forced_service.py
@@ -1,6 +1,7 @@
-
-from _vroom import _ForcedService
 from typing import Optional
+
+from .._vroom import _ForcedService
+
 
 class ForcedService(_ForcedService):
     """

--- a/src/vroom/input/input.py
+++ b/src/vroom/input/input.py
@@ -1,10 +1,9 @@
 """VROOM input definition."""
+import numpy as np
 from numpy.typing import ArrayLike
 from typing import Dict, Optional, Union
 
-import numpy
-
-from _vroom import _Input, Matrix, ROUTER, Server
+from .._vroom import _Input, Matrix, ROUTER, Server
 
 
 class Input(_Input):
@@ -87,5 +86,5 @@ class Input(_Input):
         """
         assert isinstance(profile, str)
         if not isinstance(matrix_input, Matrix):
-            matrix_input = Matrix(numpy.asarray(matrix_input, dtype="uint32"))
+            matrix_input = Matrix(np.asarray(matrix_input, dtype="uint32"))
         _Input.set_durations_matrix(self, profile, matrix_input)

--- a/src/vroom/input/vehicle_step.py
+++ b/src/vroom/input/vehicle_step.py
@@ -1,7 +1,6 @@
 from typing import Optional, Sequence, Union
 
-from _vroom import _VehicleStep, JOB_TYPE, STEP_TYPE
-
+from .._vroom import _VehicleStep, JOB_TYPE, STEP_TYPE
 from .forced_service import ForcedService
 
 

--- a/src/vroom/job.py
+++ b/src/vroom/job.py
@@ -1,13 +1,13 @@
 from typing import List, Optional, Sequence, Set, Union
 
-import vroom
-import _vroom
+from .amount import Amount
+from ._vroom import _Job, JOB_TYPE as _JOB_TYPE, Location as _Location
 
 from .location import Location
 from .time_window import TimeWindow
 
 
-class Job(_vroom._Job):
+class Job(_Job):
     """A job with deliver and/or pickup that has to be performed.
 
     Examples:
@@ -18,12 +18,12 @@ class Job(_vroom._Job):
     def __init__(
         self,
         id: int,
-        location: Union[_vroom.Location, int, Sequence[float]],
-        type: _vroom.JOB_TYPE = _vroom.JOB_TYPE.SINGLE,
+        location: Union[_Location, int, Sequence[float]],
+        type: _JOB_TYPE = _JOB_TYPE.SINGLE,
         setup: int = 0,
         service: int = 0,
-        delivery: vroom.Amount = vroom.Amount(),
-        pickup: vroom.Amount = vroom.Amount(),
+        delivery: Amount = Amount(),
+        pickup: Amount = Amount(),
         skills: Optional[Set[int]] = None,
         priority: int = 0,
         time_windows: Optional[Sequence[TimeWindow]] = None,
@@ -86,20 +86,20 @@ class Job(_vroom._Job):
         if time_windows is not None:
             kwargs["tws"] = [TimeWindow.from_args(tw)
                              for tw in kwargs.pop("time_windows")]
-        assert isinstance(type, _vroom.JOB_TYPE)
-        if type == _vroom.JOB_TYPE.SINGLE:
-            kwargs["delivery"] = vroom.Amount(delivery)
-            kwargs["pickup"] = vroom.Amount(pickup)
+        assert isinstance(type, _JOB_TYPE)
+        if type == _JOB_TYPE.SINGLE:
+            kwargs["delivery"] = Amount(delivery)
+            kwargs["pickup"] = Amount(pickup)
             del kwargs["type"]
             del self._kwargs["type"]
-        elif type == _vroom.JOB_TYPE.DELIVERY:
-            kwargs["delivery"] = vroom.Amount(delivery)
+        elif type == _JOB_TYPE.DELIVERY:
+            kwargs["delivery"] = Amount(delivery)
             assert "pickup" not in kwargs
-        elif type == _vroom.JOB_TYPE.PICKUP:
-            kwargs["pickup"] = vroom.Amount(pickup)
+        elif type == _JOB_TYPE.PICKUP:
+            kwargs["pickup"] = Amount(pickup)
             assert "delivery" not in kwargs
 
-        _vroom._Job.__init__(self, **kwargs)
+        _Job.__init__(self, **kwargs)
 
     def __repr__(self) -> str:
         kwargs = {key: value for key, value in self._kwargs.items()

--- a/src/vroom/location.py
+++ b/src/vroom/location.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from typing import Sequence, Tuple, Type, Union
 
-import _vroom
+from ._vroom import Location as _Location
 
 
-class LocationIndex(_vroom.Location):
+class LocationIndex(_Location):
     """Index in the custom duration matrix for where to find distances.
 
     Attributes:
@@ -35,13 +35,13 @@ class LocationIndex(_vroom.Location):
             self,
             index: Union[int, Location],
     ) -> None:
-        if isinstance(index, _vroom.Location):
+        if isinstance(index, _Location):
             if not index._user_index():
                 name = index.__class__.__name__
                 raise TypeError(f"Can not convert {name} to LocationIndex")
             index = index._index()
         assert isinstance(index, int)
-        _vroom.Location.__init__(self, index)
+        _Location.__init__(self, index)
         assert not self._has_coordinates()
 
     @property
@@ -53,7 +53,7 @@ class LocationIndex(_vroom.Location):
         return f"vroom.{self.__class__.__name__}({self.index})"
 
 
-class LocationCoordinates(_vroom.Location):
+class LocationCoordinates(_Location):
     """Location longitude and latitude.
 
     Attributes:
@@ -85,7 +85,7 @@ class LocationCoordinates(_vroom.Location):
         self,
         coords: Union[Location, Sequence[float]],
     ) -> None:
-        if isinstance(coords, _vroom.Location):
+        if isinstance(coords, _Location):
             if not coords._has_coordinates():
                 name = coords.__class__.__name__
                 raise TypeError(
@@ -94,7 +94,7 @@ class LocationCoordinates(_vroom.Location):
         assert isinstance(coords, Sequence)
         coords = [float(coord) for coord in coords]
         assert len(coords) == 2
-        _vroom.Location.__init__(self, coords=coords)
+        _Location.__init__(self, coords=coords)
         assert self._has_coordinates()
         assert not self._user_index()
 
@@ -148,7 +148,7 @@ class Location(LocationIndex, LocationCoordinates):
 
     """
 
-    __init__ = _vroom.Location.__init__
+    __init__ = _Location.__init__
 
     def __new__(
         cls,
@@ -158,7 +158,7 @@ class Location(LocationIndex, LocationCoordinates):
         if cls is Location and len(args)+len(kwargs) == 1:
 
             # extract args from Location{,Index,Coordinates}
-            if args and isinstance(args[0], _vroom.Location):
+            if args and isinstance(args[0], _Location):
                 args, [loc] = (), args
                 if loc._user_index():
                     args += (loc._index(),)
@@ -167,7 +167,7 @@ class Location(LocationIndex, LocationCoordinates):
 
             # single positional int -> LocationIndex
             if "index" in kwargs or args and isinstance(args[0], int):
-                instance = _vroom.Location.__new__(
+                instance = _Location.__new__(
                     LocationIndex, *args, **kwargs)
                 instance.__init__(*args, **kwargs)
                 return instance
@@ -175,12 +175,12 @@ class Location(LocationIndex, LocationCoordinates):
             # single positional sequence -> LocationCoordinates
             elif ("coords" in kwargs or args and isinstance(args[0], Sequence)
                   and len(args[0]) == 2):
-                instance = _vroom.Location.__new__(
+                instance = _Location.__new__(
                     LocationCoordinates, *args, **kwargs)
                 instance.__init__(*args, **kwargs)
                 return instance
 
-        return _vroom.Location.__new__(cls, *args, **kwargs)
+        return _Location.__new__(cls, *args, **kwargs)
 
     def __repr__(self) -> str:
         args = f"index={self.index}, coords={self.coords}"

--- a/src/vroom/time_window.py
+++ b/src/vroom/time_window.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import Union
 
 import numpy
-import _vroom
+
+from ._vroom import TimeWindow as _TimeWindow
 
 MAX_VAL = numpy.iinfo(numpy.uint32).max
 
 
-class TimeWindow(_vroom.TimeWindow):
+class TimeWindow(_TimeWindow):
     """Time window for when a delivery/pickup/task is possible.
 
     Relative values, e.g. `[0, 14400]` for a 4 hours time window starting at
@@ -53,20 +54,20 @@ class TimeWindow(_vroom.TimeWindow):
 
     def __init__(
         self,
-        start: Union[_vroom.TimeWindow, int] = 0,
+        start: Union[_TimeWindow, int] = 0,
         end: int = MAX_VAL,
     ) -> None:
         assert isinstance(end, int)
-        if isinstance(start, _vroom.TimeWindow):
+        if isinstance(start, _TimeWindow):
             if end != MAX_VAL:
                 raise TypeError("Only one arg when input is vroom.TimeWindow.")
             start, end = start.start, start.end
-        _vroom.TimeWindow.__init__(self, start=start, end=end)
+        _TimeWindow.__init__(self, start=start, end=end)
 
     def __bool__(self) -> bool:
         return self.start != 0 or self.end != MAX_VAL
 
-    def __contains__(self, other: Union[_vroom.TimeWindow, int]) -> bool:
+    def __contains__(self, other: Union[_TimeWindow, int]) -> bool:
         if isinstance(other, int):
             return self._contains(other)
         return self.start < other.start and other.end < self.end

--- a/src/vroom/vehicle.py
+++ b/src/vroom/vehicle.py
@@ -1,10 +1,6 @@
 from typing import List, Optional, Sequence, Set, Union
 
-import numpy
-
-import _vroom
-from _vroom import _Vehicle
-import vroom
+from ._vroom import _Vehicle, Location
 
 from .amount import Amount
 from .break_ import Break
@@ -17,7 +13,7 @@ class Vehicle(_Vehicle):
     """Vehicle for performing transport.
 
     Examples:
-        >>> vehicle = vroom.Vehicle(1, end=1)
+        >>> vehicle = Vehicle(1, end=1)
         >>> vehicle
         vroom.Vehicle(1, end=1)
     """
@@ -25,10 +21,10 @@ class Vehicle(_Vehicle):
     def __init__(
         self,
         id: int,
-        start: Union[None, _vroom.Location, int, Sequence[float]] = None,
-        end: Union[None, _vroom.Location, int, Sequence[float]] = None,
+        start: Union[None, Location, int, Sequence[float]] = None,
+        end: Union[None, Location, int, Sequence[float]] = None,
         profile: Optional[str] = None,
-        capacity: vroom.Amount = vroom.Amount(),
+        capacity: Amount = Amount(),
         skills: Optional[Set[int]] = None,
         time_window: Optional[TimeWindow] = None,
         breaks: Sequence[Break] = (),
@@ -42,7 +38,7 @@ class Vehicle(_Vehicle):
             start=start,
             end=end,
             profile=profile,
-            capacity=vroom.Amount(capacity),
+            capacity=Amount(capacity),
             skills=skills,
             time_window=time_window,
             breaks=breaks,

--- a/test/test_amount.py
+++ b/test/test_amount.py
@@ -1,5 +1,5 @@
 import vroom
-import _vroom
+from vroom import _vroom
 
 
 def test_amount_init():

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -1,6 +1,6 @@
 import pytest
 import vroom
-import _vroom
+from vroom import _vroom
 
 LOC_INDEX0 = _vroom.Location(index=4)
 LOC_INDEX1 = vroom.LocationIndex(4)

--- a/test/test_time_window.py
+++ b/test/test_time_window.py
@@ -1,7 +1,7 @@
 import numpy
 import pytest
 
-import _vroom
+from vroom import _vroom
 import vroom
 
 MAX_VAL = numpy.iinfo(numpy.uint32).max


### PR DESCRIPTION
fixes #15 

couldn't help myself but declaring _vroom classes with underscore. probably pointless, I guess eventually you'd rename the pybind classes instead, after the dust settled.. also doing a few things isort or similar would do, I see you got a linter issue open already. let me know if I should revert some things here.